### PR TITLE
docs: ディレクトリ規約を固定パスと参考配置に区別する

### DIFF
--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -77,14 +77,6 @@ staqkit clean --remove     # 確認の上、実際に削除
 - `data/stages/xxx/` が存在するが対応する `stage.yaml` がない（孤児）
 - `data/stages/xxx/` が存在し、status が inactive（休止中データ）
 
-### staqkit import
-
-```bash
-staqkit import --repo <url> --stages <list>
-```
-
-外部リポジトリからデータをインポートする。詳細は [外部データ](external-data.md) を参照。
-
 ## スキーマ内省・カタログ出力
 
 これらのコマンドは「テーブルの構造・意味」と「テーブルの実体（行）」を別々に見せる。`schema` / `column` は `config/table_schemas/`（[TableSchemaSet](datastore.md#tableschemaset)）由来で、データ実体がなくても引ける構造・意味の面を出力する。`catalog` は `data/stages/` 由来で、スコープ内の実データ行をダンプする。

--- a/docs/components/datastore.md
+++ b/docs/components/datastore.md
@@ -460,7 +460,7 @@ Protocol は VIEW ベースを前提とする。TABLE 対応は将来のパフ�
 
 ## 外部データアクセス
 
-外部リポジトリから取り込んだデータ（`data/external/<source>/<stage>/`）は DataStore へ直接は載せない。生データ（`data/raw/`）と同じく**ソース**として扱い、下流の取り込みステージが `extra_deps` でファイルとして読み込み、加工結果を当該プロジェクト自身の `config/table_schemas/` に従って DataStore に登録する（[external-data.md](../external-data.md)）。これにより DataStore は外部由来かどうかを一切知らずに済み、外部スキーマを転送・解釈する仕組みも不要になる。取り込みステージを通さず外部データを直接クエリすることは想定しない。
+外部リポジトリから取り込んだデータ（`data/external/<repo>/`）は DataStore へ直接は載せない。ローカル生データと同じくソースとして扱い、下流の取り込みステージが `extra_deps` でファイルとして読み込み、加工結果を当該プロジェクト自身の `config/table_schemas/` に従って DataStore に登録する（[external-data.md](../external-data.md)）。これにより DataStore は外部由来かどうかを一切知らずに済み、外部スキーマを転送・解釈する仕組みも不要になる。取り込みステージを通さず外部データを直接クエリすることは想定しない。
 
 ### 非 Parquet データの発見
 

--- a/docs/components/external-data.md
+++ b/docs/components/external-data.md
@@ -10,7 +10,7 @@
 
 ## ソースとしての扱い
 
-取り込んだデータは DataStore へ直接は載せず、生データ（`data/raw/`）と同じく**ソース**として扱う。下流の取り込みステージが `extra_deps` でファイルとして読み込み、加工結果を当該プロジェクト自身の `config/table_schemas/` に従って DataStore に登録する（[stage.md](stage.md#extra_deps-dag外の外部依存)）。
+取り込んだデータは DataStore へ直接は載せず、ローカル生データと同じくソースとして扱う。下流の取り込みステージが `extra_deps` でファイルとして読み込み、加工結果を当該プロジェクト自身の `config/table_schemas/` に従って DataStore に登録する（[stage.md](stage.md#extra_deps-dag外の外部依存)）。
 
 - 取り込みステージは `extra_deps` のソースを読み、run.py で `data/stages/<stage>/` 配下（＝当該ステージの outs）へ書き出す。非 Parquet 出力をそのまま管理下に置く場合は `run.py` で `shutil.copy` し、コピー先を `add_datastore: false` の out として宣言、パスを格納した sidecar parquet（`add_datastore: true`）を併設すると DataStore から発見できる。加工して Parquet 化する場合は `store.write_table` で `add_datastore: true` の out を書く。`staqkit add-stage --template ingest` がこの定型を生成する。
 - DataStore に入るデータは必ずそのプロジェクト自身がスキーマ契約を宣言する。これは生データ取り込みと同一の原則であり、外部だけの特例ではない。上流の公開スキーマ（標準構造そのものが外部 IF）はステージ著者が定義を書くときに参照する。
@@ -27,12 +27,16 @@
 
 ## 配置構造
 
+DAG にとって外部のソース（どのステージも生成せず、取り込みステージが消費するだけのデータ）は `data/external/` にまとめる。staqkit は `extra_deps` が宣言したパスを解決するだけで配置を強制しないため、これは一覧性のための参考配置である。
+
 ```text
-data/external/<source>/<stage>/   ← 上流の data/stages/<stage>/ をミラー
+data/external/
+  raw/          ← ローカル生データ（dvc add）
+  <repo>/       ← 別リポジトリから dvc import したデータ
 ```
 
-- `staqkit import --repo <url> --stages <list>` でステージ単位の一括取得
-- `dvc update data/external/` で一括更新
+- 取り込み: `dvc import <url> <path>` でリーフ（使いたいデータ）をコピーし、`.dvc` に `repo.url` + `rev_lock` を記録する
+- 更新: `dvc update <path>` で上流追従
 
 ## 上流の公開IF
 

--- a/docs/components/stage.md
+++ b/docs/components/stage.md
@@ -30,7 +30,7 @@ inputs:
     - source_stage: compute_cog_velocity
 
 extra_deps:
-    raw_data: data/raw/motion
+    raw_data: data/external/raw/motion
 ```
 
 ### セクションの役割
@@ -157,24 +157,24 @@ source_stage の指定漏れは「データの不在」ではなく「データ�
 
 ```yaml
 extra_deps:
-    raw_data: data/raw/motion # ディレクトリ指定
-    calibration: data/raw/calibration.csv # ファイル指定
+    raw_data: data/external/raw/motion # ディレクトリ指定
+    calibration: data/external/raw/calibration.csv # ファイル指定
     lib_utils: libs/signal_utils.py # 共有スクリプト
-    upstream_b: data/external/labA/extract/b.parquet # 外部 import データ（ソース扱い）
+    upstream_b: data/external/labA/b.parquet # 外部 import データ（ソース扱い）
 ```
 
 - globパターン（`*`, `?` 等を含む値）はジェネレータがPythonの `glob.glob()` で展開
 - glob パターンが 0 件マッチの場合はエラー（`ConfigError`）。リテラルパスの不在は DVC が deps 不在として検出するが、glob は展開結果が空になるとジェネレータが何も出力せず DVC からは見えないため、依存欠落を静かに見逃さないよう生成時に検出する
 - ディレクトリ指定はDVCネイティブの挙動（中のファイル全体をハッシュ追跡）
 - dvc.yaml の deps のみに展開。params には含めない
-- 外部リポジトリから取り込んだデータ（`data/external/<source>/<stage>/`）も生データと同じくここで宣言し、取り込みステージがソースとして読む（[external-data.md](../external-data.md)）
+- 外部リポジトリから取り込んだデータ（`data/external/<repo>/`）も生データと同じくここで宣言し、取り込みステージがソースとして読む（[external-data.md](../external-data.md)）
 
 解析コードからは `stage.extra_dep("<key>")` でパスを解決する。stage.yaml がパス定義のSSoTであり、DVC deps と解析コードの両方が同一の値を参照する。StageInfo・DataStore の定義は[実行モデル](#実行モデル)を参照。
 
 ```python
 def run(stage: StageInfo, store: DataStore):
-    raw_dir = stage.extra_dep("raw_data")      # → Path("data/raw/motion")
-    cal_file = stage.extra_dep("calibration")   # → Path("data/raw/calibration.csv")
+    raw_dir = stage.extra_dep("raw_data")      # → Path("data/external/raw/motion")
+    cal_file = stage.extra_dep("calibration")   # → Path("data/external/raw/calibration.csv")
 ```
 
 ### params（外部ファイル参照）
@@ -289,7 +289,7 @@ data/stages/normalize/timeseries.parquet    ← normalize ステージが出力
 
 実行時パラメータ・入出力ハッシュは `dvc.lock` が既に git 永続で記録するため、別途 staqkit 固有の実行記録を持つと情報が二重化する。さらに、git 管理された独立アーティファクトは `dvc.lock` の整合性機構（`dvc status` / `dvc checkout` による実体との突合）の外にあり、手編集やマージ事故で実体と乖離しても検知されず、来歴記録だけが恒久的に嘘をつきうる。来歴を `dvc.lock` + git からの導出に一本化することで、この乖離が原理的に生じない（嘘をつける独立記録が存在しない）。
 
-行数のような `dvc.lock` に無い実行サマリは記録せず、必要なときにデータ実体から再計算する。データ実体への独立性（実体が消えても来歴を読める）は、`dvc.lock` 自体が git テキストとして残るため成立する。外部から `staqkit import` で取り込んだデータの来歴は、出典元リポジトリを clone し、clone 先で同じ導出を行う（[external-data.md](external-data.md#追跡性)、[usecases.md](../usecases.md) C2a）。
+行数のような `dvc.lock` に無い実行サマリは記録せず、必要なときにデータ実体から再計算する。データ実体への独立性（実体が消えても来歴を読める）は、`dvc.lock` 自体が git テキストとして残るため成立する。外部から `dvc import` で取り込んだデータの来歴は、出典元リポジトリを clone し、clone 先で同じ導出を行う（[external-data.md](external-data.md#追跡性)、[usecases.md](../usecases.md) C2a）。
 
 ### CLIラッパー
 

--- a/docs/directory-layout.md
+++ b/docs/directory-layout.md
@@ -37,9 +37,6 @@ libs/                        ← Git管理（共有コード）。複数ステ�
   sim-model/                 ← submodule（外部リポジトリのコード/データ）
 
 data/                        ← DVC管理（成果物側）
-  raw/                       ← ソースデータ（ステージ生成物ではない）
-    motion/                  ← 計測機器からの生データ等
-    calibration.csv
   stages/                    ← ステージ出力。stages/ をミラー
     import/
       raw_motion/
@@ -51,10 +48,11 @@ data/                        ← DVC管理（成果物側）
     normalize/
       timeseries.parquet
       ...
-  external/                  ← 外部staqkitリポジトリからのimportデータ
-    <source>/
-      <stage>/
-        ...
+  external/                  ← DAG 外のソース（どのステージも生成しない）
+    raw/                     ← ローカル生データ（計測機器からの出力等）
+      motion/
+      calibration.csv
+    <repo>/                  ← 別リポジトリから dvc import したデータ
 ```
 
 ## 分離の根拠
@@ -62,6 +60,29 @@ data/                        ← DVC管理（成果物側）
 - **管理境界の明確化**: コード・設定はGit、データ成果物はDVC。混在ディレクトリだと `.gitignore` / `.dvcignore` が煩雑
 - **クリーンビルド**: `data/stages/` を丸ごと削除 → `dvc repro` で再生成が自然に可能
 - **dvc.yamlの位置づけ**: `stages/*/stage.yaml` 群から動的生成される派生物。stage.yaml がSSoT
+
+## 固定パスと参考配置
+
+構成図のパスは2種に分かれる。staqkit が場所・名前を前提に走査・導出するものは固定であり、それ以外は staqkit が宣言されたパスを解決するだけで配置を強制しない。
+
+### 固定パス（規約契約）
+
+staqkit が走査・ミラー・呼び出しの起点とするため、配置と名前を規約として固定する。
+
+- `stages/` と各ステージの `stage.yaml` / `run.py`: ステージ発見は `stages/**/stage.yaml` の再帰走査、実行は `python stages/<stage>/run.py`。ディレクトリ名・ファイル名で位置と入口が決まる。
+- `config/table_schemas/` と配下の `*.yaml`: スキーマ発見は `config/table_schemas/**/*.yaml` の再帰走査。テーブル名はファイルステムで決まる。
+- `data/stages/<stage>/`: 出力先をステージ名から機械的に導出する（`stages/` のミラー）。
+
+プロジェクト全体設定（`validation` 等）の置き場・既定値は [#26](https://github.com/sakashita44/staqkit/issues/26) で確定する。
+
+### 参考配置
+
+staqkit は `extra_deps` や params 束縛が宣言したパスをリポジトリルート相対で解決するだけで、これらの場所を前提にしない。配置は変更可能であり、構成図が示す位置は一覧性のための参考にすぎない。
+
+- `libs/`: 共有コード。`extra_deps` が任意パスで宣言する（[libs](#libs共有コード)）。
+- params ファイル（`params/` 等）: stage.yaml の束縛が指すパスを解決する（[params](#paramsパラメータ値)）。
+- `data/external/`: DAG にとって外部のソース（どのステージも生成せず、取り込みステージが消費する）。ローカル生データも別リポジトリからの dvc import も同一カテゴリで、来歴強度のみが異なる（[external-data.md](components/external-data.md)）。
+- ステージ直下の `README.md`: アルゴリズム説明。staqkit は要求も走査もしない。
 
 ## ネストディレクトリ
 
@@ -94,5 +115,5 @@ data/                        ← DVC管理（成果物側）
 
 パラメータの値は DVC ネイティブの params ファイル（任意の YAML）に置き、stage.yaml の `params` がローカル名から `{ file, key }` を束縛する（[stage.md](components/stage.md#params外部ファイル参照)）。
 
-- **配置は staqkit が規定しない**。`params/` への集約は一覧性のための推奨運用であり、強制ではない。stage.yaml の束縛が指すパス（リポジトリルート相対）を DVC が読めれば、配置はどこでもよい。
+- **配置は staqkit が規定しない**。`params/` への集約は一覧性のための参考配置であり、強制ではない。stage.yaml の束縛が指すパス（リポジトリルート相対）を DVC が読めれば、配置はどこでもよい。
 - staqkit が前提とするのは「束縛に書かれたパスをリポジトリルート相対で解決する」一点のみ。ステージごとの相対パスは生じない。

--- a/docs/usecases.md
+++ b/docs/usecases.md
@@ -101,7 +101,7 @@
 - **対応要求**: 派生（リポジトリ境界を越えた合成）
 - **典型操作**:
     1. 新リポジトリを作成（→ A1）
-    1. 親プロジェクトのデータを `staqkit import` で取り込む（→ C2）
+    1. 親プロジェクトのデータを `dvc import` で取り込む（→ C2）
     1. 新規解析を追加（→ B1）
 - **実現区分**: CLI + Pattern
 - **補足**: 親が複数（2つ以上の親プロジェクトを持つ立ち上げ）も本シナリオに含む。`dvc import` の標準パターンで親毎に取り込むだけで成立する。テンプレートコピー（親の構造を初期値としてコピーする形）は派生ではなく A4（引き継ぎ受け取り側）と等価のため本シナリオには含めない。取り込んだ親データは生データ同様のソース扱いとし、取り込みステージ（`--template ingest`）で自プロジェクトのスキーマに従って DataStore に統合する（→ C2 補足、[external-data.md](components/external-data.md)）。スキーマ転送は不要。
@@ -356,8 +356,8 @@
 
 - **目的**: 他プロジェクトの解析結果を入力ノードとして利用する
 - **対応要求**: 派生（リポジトリ境界を越えた合成）
-- **典型操作**: `staqkit import --repo <url> --stages <list>` で取り込み（→ external-data.md）
-- **実現区分**: CLI
+- **典型操作**: `dvc import <url> <path>` で取り込み（→ external-data.md）
+- **実現区分**: Git+DVC
 - **補足**: 取り込んだデータは DataStore へ直接は載せず、生データ同様のソースとして扱う。下流の取り込みステージ（`staqkit add-stage --template ingest`）が `extra_deps` でファイルとして読み、加工結果を自プロジェクトの `config/table_schemas/` に従って DataStore に登録する（→ [external-data.md](components/external-data.md)「ソースとしての扱い」）。`dvc import` で table_schemas を伝達する必要はなく、追跡性は import の `repo.url` + `rev_lock` が担保する。A6 親プロジェクト参照立ち上げも同じ扱い
 
 #### C2a. 取り込みノードの来歴を出典元 DAG まで追跡する
@@ -369,13 +369,13 @@
     1. 出典元リポジトリを別途 clone（`git clone --branch <hash>` 等）
     1. clone 先で通常の `staqkit provenance` を実行
 - **実現区分**: Git+DVC + Pattern
-- **補足**: `dvc import` が記録する `rev_lock` + `repo.url` がスナップショット参照として機能する。staqkit 側の追加ラップは不要。staqkit の責務は「参照を辿れる構造を保証する」ことに留まり、辿る操作自体はユーザが Git で行う（→ external-data.md「追跡性」）。`staqkit import` 時に出典元の来歴を自リポへ同梱する仕様は持たない。出典元を clone すれば、その `dvc.lock` + git 履歴から通常どおり来歴を導出でき、DVC remote へのアクセスは不要（→ stage.md「来歴の所在」）
+- **補足**: `dvc import` が記録する `rev_lock` + `repo.url` がスナップショット参照として機能する。staqkit 側の追加ラップは不要。staqkit の責務は「参照を辿れる構造を保証する」ことに留まり、辿る操作自体はユーザが Git で行う（→ external-data.md「追跡性」）。`dvc import` が出典元の来歴を自リポへ同梱する仕様は持たない。出典元を clone すれば、その `dvc.lock` + git 履歴から通常どおり来歴を導出でき、DVC remote へのアクセスは不要（→ stage.md「来歴の所在」）
 
 #### C2b. 取り込み元 DAG の更新を反映する
 
 - **目的**: 出典元リポジトリの最新版を自プロジェクトに取り込み直す
 - **対応要求**: 派生（リポジトリ境界を越えた合成）
-- **典型操作**: `dvc update data/external/<source>/<stage>/` で一括更新
+- **典型操作**: `dvc update <path>` で取り込み先を更新
 - **実現区分**: Git+DVC
 - **補足**: external-data.md「取り込み」で `dvc update` による明示的追従が方針として確定。更新検知の自動化は現状未対応（手動判断）
 


### PR DESCRIPTION
## 関連 Issue

closes #24

## 変更内容

`docs/directory-layout.md` は各ディレクトリを一様な構成図として提示しており、staqkit が走査・ミラー・生成で前提とする固定パスと、ユーザが変更可能な配置を読者が判別できなかった。この区別を明示し、調査の過程で判明した陳腐化（`staqkit import` ラッパー、external の固定ミラー構造）も合わせて整理した。

### 固定/参考の区別

- `directory-layout.md` に「固定パスと参考配置」節を新設。固定パス（`stages/`・`stage.yaml`・`run.py`／`config/table_schemas/`＋`*.yaml`／`data/stages/<stage>/`）は staqkit が走査・ミラー・呼び出しの起点とするため規約契約として固定。参考配置（`libs/`・params ファイル・`data/external/`・ステージ直下 `README.md`）は staqkit が宣言パスを解決するだけで配置を強制しない。

### external を参考配置へ再分類

- 取り込みデータはローカル生データと同一カテゴリの「ソース」であり、差は来歴強度のみ（external は `dvc import` の `repo.url`+`rev_lock`、raw は `dvc add`）。配置の固定性はない。
- `data/external/<source>/<stage>/` の固定ミラー構造をやめ、`data/external/{raw,<repo>}/` に統合した参考配置に簡素化。「external＝この DAG にとって外部（どのステージも生成せず消費のみ）」と定義し直した。

### staqkit import の廃止

- 取り込みはデータ依存（`extra_deps` で読むファイル）であり、出典・スナップショット固定・鮮度伝搬を `dvc import` / `dvc update` が `.dvc` のハッシュで担保する。薄いラッパーは付加価値を持たないため `cli.md` から削除し、標準操作へ委ねた。

### 波及整合

- `stage.md`・`datastore.md`・`usecases.md` の `data/raw/`・`data/external/<source>/<stage>/`・`staqkit import` 参照を `dvc import` と統一命名へ揃えた（C2 の実現区分も CLI → Git+DVC）。

### 委譲

- プロジェクト全体設定（`validation` 等）の置き場・既定値は #26 で確定する旨を明示。

判断理由の詳細（固定＝規約契約とする根拠／`data/stages` ミラーの必要性／external==raw／import 廃止の論証）は [#24 のコメント](https://github.com/sakashita44/staqkit/issues/24#issuecomment-4756905600) に記録済み。

## ドキュメント

- [x] 影響するドキュメントを更新した