### PR TITLE
docs: 部分導入時の validate を宣言範囲検査として確定する

### DIFF
--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -57,9 +57,13 @@ staqkit validate --target descriptions # description 網羅検査のみ
 
 引数なしで横断的なフルチェックを実行する。全検査群を回す `staqkit validate` が保証の本体であり、A3（引き継ぎ）・A5（公開）のゲートはこれに依存する。`--target` は編集ループ中に「いま触っている部分だけ」を回すための便宜フィルタであり、検査群の網羅的な列挙でも硬い契約でもない。検査群が増えても、単独実行したい編集ループの局面がある場合にだけ既存のいずれかへ寄せ、なければフル実行に委ねる。トップレベルの検査コマンドは増やさず、`staqkit validate` を統合エントリに保つ。
 
+検査対象は宣言範囲に限る。stage.yaml の `outs`・そこで参照される table_schemas・params 束縛が宣言範囲を成し、宣言していない同居ファイルは staqkit から不可視で、生のファイルパス経由でのみ読める。`outs` に `add_datastore: true` で宣言した出力はスキーマ検査対象となり、対応する table_schema がなければ error となる。`add_datastore: false` の出力はスキーマ検査対象外。導入の深浅は宣言した量の差であり、宣言範囲の error を解消すればその範囲で保証が成立する。
+
 - 参照整合性（source_stage の実在確認・循環検出、params 束縛先 `file`・`key` の実在確認）: `--target references`
 - スキーマ整合性（Parquet ファイル vs `config/table_schemas/`）+ TableSchemaSet 整合性（FK 参照先の存在・型一致）: `--target schema`
 - description 網羅検査（説明欄充足・説明系ファイル存在）と column_descriptions 未記述の警告: `--target descriptions`
+
+validate error は runtime が強制する契約に対応する。validate は宣言範囲を先回りで一括検査し、runtime（`staqkit repro`・DataStore の読み書き）は実行・アクセスした範囲だけを硬く強制する。両者は独立したゲートであり、validate の通過は runtime の前提条件ではない。参照整合性は pipeline-gen と repro、スキーマ契約は DataStore の読み書きで同じ契約が再強制され、description 網羅検査は runtime に波及せず A3・A5 のゲート向けの警告に留まる。設計時と実行時のこの粒度差は[アクセス経路の保証グラデーション](../architecture.md#守る契約とアクセス経路の保証グラデーション)に従う。
 
 検査群の責務分割の経緯と方針（CLI コマンドを増やさず `--target` フラグで出し分ける判断）は [#19](https://github.com/sakashita44/staqkit/issues/19) で確定済み。キャッチオール検査対象ファイルの具体的列挙など残る詳細は validate 実装時に確定する。
 

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -57,7 +57,7 @@ staqkit validate --target descriptions # description 網羅検査のみ
 
 引数なしで横断的なフルチェックを実行する。全検査群を回す `staqkit validate` が保証の本体であり、A3（引き継ぎ）・A5（公開）のゲートはこれに依存する。`--target` は編集ループ中に「いま触っている部分だけ」を回すための便宜フィルタであり、検査群の網羅的な列挙でも硬い契約でもない。検査群が増えても、単独実行したい編集ループの局面がある場合にだけ既存のいずれかへ寄せ、なければフル実行に委ねる。トップレベルの検査コマンドは増やさず、`staqkit validate` を統合エントリに保つ。
 
-検査対象は宣言範囲に限る。stage.yaml の `outs`・そこで参照される table_schemas・params 束縛が宣言範囲を成し、宣言していない同居ファイルは staqkit から不可視で、生のファイルパス経由でのみ読める。`outs` に `add_datastore: true` で宣言した出力はスキーマ検査対象となり、対応する table_schema がなければ error となる。`add_datastore: false` の出力はスキーマ検査対象外。導入の深浅は宣言した量の差であり、宣言範囲の error を解消すればその範囲で保証が成立する。
+検査対象は宣言範囲に限る。stage.yaml の `outs`・そこで参照される table_schemas・params 束縛が宣言範囲を成し、宣言していない同居ファイルは staqkit から不可視で、生のファイルパス経由でのみ読める。`outs` に `add_datastore: true` で宣言した出力はスキーマ検査対象となり、対応する table_schema（`config/table_schemas/` 配下の定義）がなければ error となる。`add_datastore: false` の出力はスキーマ検査対象外。導入の深浅は宣言した量の差であり、宣言範囲の error を解消すればその範囲で保証が成立する。
 
 - 参照整合性（source_stage の実在確認・循環検出、params 束縛先 `file`・`key` の実在確認）: `--target references`
 - スキーマ整合性（Parquet ファイル vs `config/table_schemas/`）+ TableSchemaSet 整合性（FK 参照先の存在・型一致）: `--target schema`

--- a/docs/usecases.md
+++ b/docs/usecases.md
@@ -58,7 +58,7 @@ staqkit の利用シナリオを体系化し、CLI 体系・Project 層の組み
     1. table_schemas を既存データから逆算して定義
     1. `staqkit validate` で整合確認
 - **実現区分**: CLI + Pattern
-- **補足**: **(TODO)** 「部分導入」を許す段階的移行パターンの整理が必要。validate が「全部 staqkit 化されていない状態」を許容するかが論点
+- **補足**: validate は宣言範囲（stage.yaml の `outs`・参照する table_schemas 等）のみを検査し、宣言していない同居ファイルは対象外となる（staqkit システムから不可視で、生のファイルパス経由でのみ読める）。部分導入は宣言した量の差であり、宣言範囲の validate error を解消すればその範囲で staqkit の保証を得る（→ [components/cli.md](components/cli.md#staqkit-validate)）
 
 ### A3. プロジェクトを引き継ぐ（受け渡し側）
 
@@ -603,7 +603,6 @@ DAG の辺（処理）の再利用。requirements.md では核要求から派生
 
 | ID     | 内容                                                                 | 関連 issue |
 | ------ | -------------------------------------------------------------------- | ---------- |
-| A2     | 部分導入を許す段階的移行パターン                                     | #29        |
 | B17    | 結果比較支援を staqkit が薄く提供する価値があるか                    | #28        |
 | D3     | status の出力フォーマット拡張（planned/inactive 表示等）の要否       | #28        |
 | D4     | スナップショット再現性確認の専用フラグ要否                           | #28        |


### PR DESCRIPTION
## 関連 Issue

closes #29

## 変更内容

- usecases A2 補足を規則記述に確定（未整理 TODO を除去）
- 未仕様ポイント一覧から A2 行を削除
- cli.md validate に検査範囲（宣言範囲）と validate/runtime の関係を追記

## ドキュメント

- [x] 影響するドキュメントを更新した
- [ ] ドキュメント更新が不要（理由: ）

---

## 設計判断の経緯

### 論点

既存プロジェクトへ staqkit を後付け導入する途中、まだ staqkit 構造に入っていない部分が同居する状態を `staqkit validate` がどこまで許容するか（A2）。専用の緩和モードやフラグを設けるべきか。

### 確定した方針

宣言範囲のみを検査する。導入の深浅は「どれだけ宣言したか」の差でしかなく、部分導入のための特別な機構（`--partial` 等のフラグ・緩和モード・新状態）は設けない。

- 検査範囲は stage.yaml の `outs`・参照される table_schemas・params 束縛が成す宣言範囲に限る。未宣言の同居ファイルは staqkit から不可視で、生のファイルパス経由でのみ読める。
- 物理的なファイル存在をトリガーにしない。`outs` に `add_datastore: true` で宣言した出力はスキーマ検査対象となり table_schema がなければ error、`add_datastore: false` の出力は非テーブルとして検査対象外、`outs` に無いファイル（`.gitkeep`・memo・png・迷子の parquet 等）は不可視。この三層は既存の `outs` / `add_datastore` 設計が既に担っている。
- 宣言範囲の validate error を解消すればその範囲で保証が成立するため、初期導入と途中導入の操作は同じに畳まれる。段階的移行を特別なパターンとして記述する必然がなくなる。

### validate と runtime の関係

両者は独立ゲートであり、validate の通過は runtime の前提条件ではない。同じ契約を、validate が全体を先回りで一括検査し、runtime が実行・アクセスした範囲だけを硬く強制する（設計時緩く・実行時硬く）。

- 参照整合性: pipeline-gen / repro で再強制（effective-active に限る）
- スキーマ契約: DataStore の読み書き（on_read / on_write）で再強制
- description 網羅: runtime に波及せず、引き継ぎ・公開（A3/A5）ゲート向けの警告に留まる

validate error は runtime が硬く強制する契約に対応するため「staqkit として使うなら error を全解消」となる。warn は runtime が強制しない事柄で、単体で実行を止めない。

### planned との区別

planned は「導入済みプロジェクト内で宣言のみ・実体なし」の軸であり、未導入（未宣言・不可視）とは別フェーズ。両者は混同しないため、未導入は宣言範囲外として沈黙で扱い、新しい状態・概念を追加しない。
