### PR TITLE
docs: dvc.yaml を Git 管理に改め素の Git+DVC 操作で復元を成立させる

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,11 +162,17 @@ staqkit 内の状態は一方向の導出関係に従う。stage.yaml の status
 
 ### パイプライン定義の扱い
 
-dvc.yaml は stage.yaml から常に導出可能なため、Git管理対象外とする。DVCネイティブツール（`dvc dag` 等）が直接使えないトレードオフを受容し、SSoTの一元性を優先する。
+dvc.yaml は stage.yaml 群から生成される派生物であり、dvc.lock と対で Git 管理する。DVC は pull / checkout / status の対象列挙を dvc.yaml と `.dvc` ファイル群から行うため、コミットに dvc.yaml が含まれることで、パイプライン outs の復元（`dvc pull` / `dvc checkout`）が素の Git+DVC 操作だけで成立する。DVC ネイティブツール（`dvc dag` 等）も直接使える。
+
+SSoT は stage.yaml に置いたまま、dvc.yaml との整合は生成と検査で維持する（[pipeline-gen.md](components/pipeline-gen.md#整合性の維持)）。
+
+- stage.yaml / dvc.yaml に触れる staqkit コマンドは dvc.yaml を再生成し、変更を `git add` する
+- dvc をラップするコマンド（repro / status）は dvc 呼び出しの前に dvc.yaml を再生成する
+- `staqkit validate` は dvc.yaml が stage.yaml 群からの生成結果と一致することを検査する
 
 ### 実験追跡
 
-DVC Experimentsは現時点では採用しない。来歴追跡（`dvc.lock` + git 履歴からの導出）とは関心の層が異なり、dvc.yaml 非Git管理方針との整合性からも現時点では利用不可。後から追加可能な設計を維持する。
+DVC Experimentsは現時点では採用しない。来歴追跡（`dvc.lock` + git 履歴からの導出）とは関心の層が異なる。後から追加可能な設計を維持する。
 
 ### バリデーション
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,11 +164,7 @@ staqkit 内の状態は一方向の導出関係に従う。stage.yaml の status
 
 dvc.yaml は stage.yaml 群から生成される派生物であり、dvc.lock と対で Git 管理する。DVC は pull / checkout / status の対象列挙を dvc.yaml と `.dvc` ファイル群から行うため、コミットに dvc.yaml が含まれることで、パイプライン outs の復元（`dvc pull` / `dvc checkout`）が素の Git+DVC 操作だけで成立する。DVC ネイティブツール（`dvc dag` 等）も直接使える。
 
-SSoT は stage.yaml に置いたまま、dvc.yaml との整合は生成と検査で維持する（[pipeline-gen.md](components/pipeline-gen.md#整合性の維持)）。
-
-- stage.yaml / dvc.yaml に触れる staqkit コマンドは dvc.yaml を再生成し、変更を `git add` する
-- dvc をラップするコマンド（repro / status）は dvc 呼び出しの前に dvc.yaml を再生成する
-- `staqkit validate` は dvc.yaml が stage.yaml 群からの生成結果と一致することを検査する
+SSoT は stage.yaml に置いたまま、dvc.yaml との整合は変更時・利用時の再生成と `staqkit validate` の整合検査で維持する。同期点・add 対象・検査方式の詳細は [pipeline-gen.md](components/pipeline-gen.md#整合性の維持) に一本化する。
 
 ### 実験追跡
 

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -10,7 +10,7 @@
 staqkit repro [stage]
 ```
 
-stage.yaml 群から dvc.yaml を動的生成 → 最小限バリデーション → `dvc repro` を実行する。stage を指定すると対象ステージとその上流のみ再実行する。
+stage.yaml 群から dvc.yaml を再生成 → 最小限バリデーション → `dvc repro` を実行する。再生成された dvc.yaml と、実行で更新された dvc.lock は `git add` される（[pipeline-gen.md](pipeline-gen.md#整合性の維持)）。stage を指定すると対象ステージとその上流のみ再実行する。
 
 ### staqkit status
 
@@ -18,7 +18,7 @@ stage.yaml 群から dvc.yaml を動的生成 → 最小限バリデーション
 staqkit status
 ```
 
-stage.yaml 群から dvc.yaml を動的生成 → `dvc status` を実行し、各ステージの鮮度を表示する。
+stage.yaml 群から dvc.yaml を再生成 → `dvc status` を実行し、各ステージの鮮度を表示する。再生成で dvc.yaml が変化した場合は `git add` される。
 
 ### staqkit dag
 
@@ -38,6 +38,7 @@ staqkit add-stage <path> [--status <active|planned|inactive>] [--template <defau
 
 新しいステージのディレクトリ（`stages/<path>/`）に stage.yaml と run.py のボイラープレートを生成する。プロジェクト全体の初期化は Copier が担い、本コマンドは既存プロジェクト内へのステージ追加に専念する（[distribution.md](../distribution.md#初期化とステージ追加の責務分担)）。
 
+- 生成後に dvc.yaml を再生成し、生成物とともに `git add` する（[pipeline-gen.md](pipeline-gen.md#整合性の維持)）。
 - `--status`: 初期状態（既定: planned。宣言の先行＝実体に先立つ宣言と整合）。
 - `--template`: run.py 雛形の種別。`default` は通常ステージ（`store.query` → 加工 → `store.write_table`）、`ingest` は生データ・外部 import データをソースとして取り込む取り込みステージ（`extra_deps` でソースを受け、非 Parquet 出力は `add_datastore: false`、パスを格納した sidecar parquet で DataStore から発見可能にする。[external-data.md](external-data.md)、[#6](https://github.com/sakashita44/staqkit/issues/6)）。
 - 既存ステージ（同一パス）と重複する場合はエラー終了する。
@@ -59,6 +60,7 @@ staqkit validate --target descriptions # description 網羅検査のみ
 
 検査対象は宣言範囲に限る。stage.yaml の `outs`・そこで参照される table_schemas・params 束縛が宣言範囲を成し、宣言していない同居ファイルは staqkit から不可視で、生のファイルパス経由でのみ読める。`outs` に `add_datastore: true` で宣言した出力はスキーマ検査対象となり、対応する table_schema（`config/table_schemas/` 配下の定義）がなければ error となる。`add_datastore: false` の出力はスキーマ検査対象外。導入の深浅は宣言した量の差であり、宣言範囲の error を解消すればその範囲で保証が成立する。
 
+- パイプライン定義整合（dvc.yaml が stage.yaml 群からの生成結果と意味的に一致。[pipeline-gen.md](pipeline-gen.md#整合性の維持)）: フル実行に含まれる（`--target` の個別枠は設けない）
 - 参照整合性（source_stage の実在確認・循環検出、params 束縛先 `file`・`key` の実在確認）: `--target references`
 - スキーマ整合性（Parquet ファイル vs `config/table_schemas/`）+ TableSchemaSet 整合性（FK 参照先の存在・型一致）: `--target schema`
 - description 網羅検査（説明欄充足・説明系ファイル存在）と column_descriptions 未記述の警告: `--target descriptions`

--- a/docs/components/cli.md
+++ b/docs/components/cli.md
@@ -10,7 +10,7 @@
 staqkit repro [stage]
 ```
 
-stage.yaml 群から dvc.yaml を再生成 → 最小限バリデーション → `dvc repro` を実行する。再生成された dvc.yaml と、実行で更新された dvc.lock は `git add` される（[pipeline-gen.md](pipeline-gen.md#整合性の維持)）。stage を指定すると対象ステージとその上流のみ再実行する。
+stage.yaml 群から dvc.yaml を再生成 → 最小限バリデーション → `dvc repro` を実行する。再生成された dvc.yaml と、実行で更新された dvc.lock のみが `git add` される（[pipeline-gen.md](pipeline-gen.md#整合性の維持)）。stage を指定すると対象ステージとその上流のみ再実行する。
 
 ### staqkit status
 
@@ -18,7 +18,7 @@ stage.yaml 群から dvc.yaml を再生成 → 最小限バリデーション �
 staqkit status
 ```
 
-stage.yaml 群から dvc.yaml を再生成 → `dvc status` を実行し、各ステージの鮮度を表示する。再生成で dvc.yaml が変化した場合は `git add` される。
+stage.yaml 群から dvc.yaml を再生成 → `dvc status` を実行し、各ステージの鮮度を表示する。再生成で dvc.yaml が変化した場合はその旨を出力に含める。git index には触れない（[pipeline-gen.md](pipeline-gen.md#整合性の維持)）。
 
 ### staqkit dag
 
@@ -38,7 +38,7 @@ staqkit add-stage <path> [--status <active|planned|inactive>] [--template <defau
 
 新しいステージのディレクトリ（`stages/<path>/`）に stage.yaml と run.py のボイラープレートを生成する。プロジェクト全体の初期化は Copier が担い、本コマンドは既存プロジェクト内へのステージ追加に専念する（[distribution.md](../distribution.md#初期化とステージ追加の責務分担)）。
 
-- 生成後に dvc.yaml を再生成し、生成物とともに `git add` する（[pipeline-gen.md](pipeline-gen.md#整合性の維持)）。
+- 生成後に dvc.yaml を再生成する。`git add` の対象は新規ステージ配下の生成物（stage.yaml・run.py）と dvc.yaml のみ（[pipeline-gen.md](pipeline-gen.md#整合性の維持)）。
 - `--status`: 初期状態（既定: planned。宣言の先行＝実体に先立つ宣言と整合）。
 - `--template`: run.py 雛形の種別。`default` は通常ステージ（`store.query` → 加工 → `store.write_table`）、`ingest` は生データ・外部 import データをソースとして取り込む取り込みステージ（`extra_deps` でソースを受け、非 Parquet 出力は `add_datastore: false`、パスを格納した sidecar parquet で DataStore から発見可能にする。[external-data.md](external-data.md)、[#6](https://github.com/sakashita44/staqkit/issues/6)）。
 - 既存ステージ（同一パス）と重複する場合はエラー終了する。
@@ -60,10 +60,11 @@ staqkit validate --target descriptions # description 網羅検査のみ
 
 検査対象は宣言範囲に限る。stage.yaml の `outs`・そこで参照される table_schemas・params 束縛が宣言範囲を成し、宣言していない同居ファイルは staqkit から不可視で、生のファイルパス経由でのみ読める。`outs` に `add_datastore: true` で宣言した出力はスキーマ検査対象となり、対応する table_schema（`config/table_schemas/` 配下の定義）がなければ error となる。`add_datastore: false` の出力はスキーマ検査対象外。導入の深浅は宣言した量の差であり、宣言範囲の error を解消すればその範囲で保証が成立する。
 
-- パイプライン定義整合（dvc.yaml が stage.yaml 群からの生成結果と意味的に一致。[pipeline-gen.md](pipeline-gen.md#整合性の維持)）: フル実行に含まれる（`--target` の個別枠は設けない）
 - 参照整合性（source_stage の実在確認・循環検出、params 束縛先 `file`・`key` の実在確認）: `--target references`
 - スキーマ整合性（Parquet ファイル vs `config/table_schemas/`）+ TableSchemaSet 整合性（FK 参照先の存在・型一致）: `--target schema`
 - description 網羅検査（説明欄充足・説明系ファイル存在）と column_descriptions 未記述の警告: `--target descriptions`
+
+宣言範囲の検査とは別に、フル実行は派生物の整合検査を一つ含む。パイプライン定義整合（dvc.yaml が stage.yaml 群からの生成結果と意味的に一致すること。[pipeline-gen.md](pipeline-gen.md#整合性の維持)）は宣言の中身ではなく生成物と宣言の同期を検査するもので、編集ループで単独実行する局面がないため `--target` の個別枠は設けない。
 
 validate error は runtime が強制する契約に対応する。validate は宣言範囲を先回りで一括検査し、runtime（`staqkit repro`・DataStore の読み書き）は実行・アクセスした範囲だけを硬く強制する。両者は独立したゲートであり、validate の通過は runtime の前提条件ではない。参照整合性は pipeline-gen と repro、スキーマ契約は DataStore の読み書きで同じ契約が再強制され、description 網羅検査は runtime に波及せず A3・A5 のゲート向けの警告に留まる。設計時と実行時のこの粒度差は[アクセス経路の保証グラデーション](../architecture.md#守る契約とアクセス経路の保証グラデーション)に従う。
 

--- a/docs/components/pipeline-gen.md
+++ b/docs/components/pipeline-gen.md
@@ -1,6 +1,6 @@
 # パイプライン生成
 
-dvc.yaml は `stages/*/stage.yaml` 群から動的に生成される派生物であり、Git管理しない。`dvc.lock` のみGit管理。ルートに単一の dvc.yaml を生成する。
+dvc.yaml は `stages/*/stage.yaml` 群から生成される派生物であり、`dvc.lock` と対で Git 管理する。ルートに単一の dvc.yaml を生成する。stage.yaml が SSoT であり、dvc.yaml は手編集の対象としない（再生成で上書きされる）。
 
 `dvc.lock` は各ステージの実行時パラメータ・入出力ハッシュを commit 単位で記録するため、来歴追跡（T1）の源泉も兼ねる。`staqkit provenance` / `staqkit history` は `dvc.lock` と git 履歴からチェーンを導出する（[stage.md](stage.md#来歴の所在)）。
 
@@ -36,16 +36,32 @@ staqkit catalog             # テーブルカタログ出力（→ stdout）
 
 active ステージが inputs で planned ステージを参照する場合、参照先 outs は dvc.yaml に存在せず実行できない。`staqkit validate` は警告に留め、`staqkit repro` は `ReferenceIntegrityError` で停止する（[stage.md](stage.md#active-が-planned-を参照した場合)）。検査は実行対象（effective-active）にのみ発火するため、planned から planned への参照は対象外。
 
+## 生成の決定性
+
+同一の stage.yaml 群と同一の staqkit バージョンからは、バイト単位で同一の dvc.yaml を生成する。ステージの列挙順・キー順・フォーマットを正規化し、生成に環境依存の要素を含めない。整合検査はこの決定性を前提とする。
+
+## 整合性の維持
+
+stage.yaml と dvc.yaml の同期点を二つ置く。
+
+- 変更時: stage.yaml / dvc.yaml に触れるコマンド（repro / status / add-stage）は dvc.yaml を再生成し、変更があれば `git add` まで行う
+- 利用時: dvc をラップするコマンド（repro / status）は dvc 呼び出しの前に必ず再生成する。dvc が古い dvc.yaml を参照して動く経路を staqkit コマンド上に残さない
+
+`staqkit validate` は dvc.yaml が stage.yaml 群からの生成結果と一致することを検査する。比較はパース後の意味比較（ステージ集合・cmd・deps・params・outs・desc）で行う。バイト比較を避けるのは、staqkit バージョン間のフォーマット差が過去スナップショットの検査で偽陽性になることを防ぐためである。
+
+この構成での整合保証は次のとおり。staqkit コマンドを経由した操作では乖離は発生しない。staqkit を経由しない変更（stage.yaml の手編集後の直接コミット、merge による書き換え等）で乖離したコミットが生じた場合も、任意のスナップショットに対する `staqkit validate` で検出できる。コミット時の自動検査（pre-commit フック）と CI での validate 実行は雛形が提供する（[distribution.md](../distribution.md#雛形と改善の伝播)）。これらの有効化は利用者の設定（`pre-commit install`、ブランチ保護）に依る。
+
 ## バリデーション
 
-| 検査項目                                           | validate（フル） | repro（最小限） |
-| -------------------------------------------------- | ---------------- | --------------- |
-| 参照整合性（source_stage 実在・循環検出）          | YES              | YES             |
-| active が planned を inputs 参照                   | YES（警告）      | YES（エラー）   |
-| extra_deps の glob が 0 件マッチ                   | YES（エラー）    | YES（エラー）   |
-| スキーマ整合性（parquet vs config/table_schemas/） | YES              | ---             |
-| TableSchemaSet 整合性（FK 参照先・型一致）         | YES              | ---             |
-| column_descriptions 未記述                         | YES（警告）      | ---             |
+| 検査項目                                           | validate（フル） | repro（最小限）               |
+| -------------------------------------------------- | ---------------- | ----------------------------- |
+| dvc.yaml と stage.yaml の整合                      | YES              | ---（実行前再生成で常に成立） |
+| 参照整合性（source_stage 実在・循環検出）          | YES              | YES                           |
+| active が planned を inputs 参照                   | YES（警告）      | YES（エラー）                 |
+| extra_deps の glob が 0 件マッチ                   | YES（エラー）    | YES（エラー）                 |
+| スキーマ整合性（parquet vs config/table_schemas/） | YES              | ---                           |
+| TableSchemaSet 整合性（FK 参照先・型一致）         | YES              | ---                           |
+| column_descriptions 未記述                         | YES（警告）      | ---                           |
 
 `staqkit validate` の各検査群は `--target schema|references|descriptions` で個別実行でき、編集ループ中の部分検証に使える（[cli.md](cli.md#staqkit-validate)）。
 

--- a/docs/components/pipeline-gen.md
+++ b/docs/components/pipeline-gen.md
@@ -44,8 +44,8 @@ active ステージが inputs で planned ステージを参照する場合、�
 
 stage.yaml と dvc.yaml の同期点を二つ置く。
 
-- 変更時: stage.yaml / dvc.yaml に触れるコマンド（repro / status / add-stage）は dvc.yaml を再生成し、変更があれば `git add` まで行う
-- 利用時: dvc をラップするコマンド（repro / status）は dvc 呼び出しの前に必ず再生成する。dvc が古い dvc.yaml を参照して動く経路を staqkit コマンド上に残さない
+- 変更時: パイプライン状態を進めるコマンド（repro / add-stage）は dvc.yaml を再生成し、変更があれば `git add` まで行う。add の対象は各コマンドが書き換えたパイプラインファイルに限る（repro は dvc.yaml と dvc.lock、add-stage は dvc.yaml と新規ステージの生成物）
+- 利用時: dvc をラップするコマンド（repro / status）は dvc 呼び出しの前に必ず再生成する。dvc が古い dvc.yaml を参照して動く経路を staqkit コマンド上に残さない。status は再生成で dvc.yaml が変化した場合その旨を出力に含め、`git add` は行わない
 
 `staqkit validate` は dvc.yaml が stage.yaml 群からの生成結果と一致することを検査する。比較はパース後の意味比較（ステージ集合・cmd・deps・params・outs・desc）で行う。バイト比較を避けるのは、staqkit バージョン間のフォーマット差が過去スナップショットの検査で偽陽性になることを防ぐためである。
 

--- a/docs/directory-layout.md
+++ b/docs/directory-layout.md
@@ -60,7 +60,7 @@ data/                        ← DVC管理（成果物側）
 
 - **管理境界の明確化**: コード・設定はGit、データ成果物はDVC。混在ディレクトリだと `.gitignore` / `.dvcignore` が煩雑
 - **クリーンビルド**: `data/stages/` を丸ごと削除 → `dvc repro` で再生成が自然に可能
-- **dvc.yamlの位置づけ**: `stages/*/stage.yaml` 群から動的生成される派生物。stage.yaml がSSoT
+- **dvc.yamlの位置づけ**: `stages/*/stage.yaml` 群から生成される派生物で、dvc.lock と対で Git 管理する。stage.yaml がSSoT
 
 ## 固定パスと参考配置
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -20,7 +20,7 @@ staqkit は単一の Python パッケージとして配布する。
 配布の対象を性質の異なる二つに分ける。
 
 - **staqkit 本体（ツール・ランタイムのコード）**: 通常の Python パッケージ。改善の取り込みは `uv lock --upgrade` でのバージョン更新で完了する。
-- **プロジェクト雛形（各リポジトリにファイルとして焼かれる初期構成）**: CI 設定、pre-commit 設定、`.gitignore` / `.dvcignore`、stage.yaml のサンプル、空のディレクトリ枠など。CI 設定と pre-commit 設定は `staqkit validate` の実行を含み、dvc.yaml と stage.yaml の整合検査（[pipeline-gen.md](components/pipeline-gen.md#整合性の維持)）をコミット時・push 時に掛ける。
+- **プロジェクト雛形（各リポジトリにファイルとして焼かれる初期構成）**: CI 設定、pre-commit 設定、`.gitignore` / `.dvcignore`、stage.yaml のサンプル、空のディレクトリ枠など。pre-commit 設定はコミット時に、CI 設定は push / PR 時に、それぞれ `staqkit validate` を実行して dvc.yaml と stage.yaml の整合検査（[pipeline-gen.md](components/pipeline-gen.md#整合性の維持)）を掛ける。
 
 パッケージのコードはバージョン更新で全プロジェクトに伝播する。生成時に各リポジトリへ焼かれた雛形ファイルは、以後そのリポジトリの一部となり版更新の影響を受けない。この非対称性に沿って、振る舞い（ロジック）は staqkit パッケージに置き、雛形は staqkit パッケージに置けない各プロジェクト固有のボイラープレートに限定する。
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -20,7 +20,7 @@ staqkit は単一の Python パッケージとして配布する。
 配布の対象を性質の異なる二つに分ける。
 
 - **staqkit 本体（ツール・ランタイムのコード）**: 通常の Python パッケージ。改善の取り込みは `uv lock --upgrade` でのバージョン更新で完了する。
-- **プロジェクト雛形（各リポジトリにファイルとして焼かれる初期構成）**: CI 設定、`.gitignore` / `.dvcignore`、stage.yaml のサンプル、空のディレクトリ枠など。
+- **プロジェクト雛形（各リポジトリにファイルとして焼かれる初期構成）**: CI 設定、pre-commit 設定、`.gitignore` / `.dvcignore`、stage.yaml のサンプル、空のディレクトリ枠など。CI 設定と pre-commit 設定は `staqkit validate` の実行を含み、dvc.yaml と stage.yaml の整合検査（[pipeline-gen.md](components/pipeline-gen.md#整合性の維持)）をコミット時・push 時に掛ける。
 
 パッケージのコードはバージョン更新で全プロジェクトに伝播する。生成時に各リポジトリへ焼かれた雛形ファイルは、以後そのリポジトリの一部となり版更新の影響を受けない。この非対称性に沿って、振る舞い（ロジック）は staqkit パッケージに置き、雛形は staqkit パッケージに置けない各プロジェクト固有のボイラープレートに限定する。
 

--- a/docs/usecases.md
+++ b/docs/usecases.md
@@ -437,7 +437,7 @@ staqkit の利用シナリオを体系化し、CLI 体系・Project 層の組み
 - **対応要求**: 委譲（DAG整合性・鮮度）
 - **典型操作**: `staqkit status` を実行
 - **実現区分**: CLI
-- **補足**: dvc.yaml は staqkit 全体として派生物扱いであり Git 非管理（→ [architecture.md](architecture.md) / [components/pipeline-gen.md](components/pipeline-gen.md)）。`staqkit status` は repro 等と同じ生成プロローグを共有した上で `dvc status` を呼ぶラッパーであり、動的生成は本 UC 固有の付加価値ではない。`dvc status` の出力分類のうち changed deps が本 UC の主関心、missing data + changed outs は再現性確認（→ D4）の関心。**(検討中)** planned/inactive の表示や stage 状態併記など、出力フォーマット拡張の要否
+- **補足**: dvc.yaml は stage.yaml 群から生成され Git 管理される派生物（→ [architecture.md](architecture.md) / [components/pipeline-gen.md](components/pipeline-gen.md)）。`staqkit status` は repro 等と同じ再生成プロローグを共有した上で `dvc status` を呼ぶラッパーであり、再生成は本 UC 固有の付加価値ではない。`dvc status` の出力分類のうち changed deps が本 UC の主関心、missing data + changed outs は再現性確認（→ D4）の関心。**(検討中)** planned/inactive の表示や stage 状態併記など、出力フォーマット拡張の要否
 
 ### D4. clone した状態が再現できているか確認する
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 関連 Issue

closes #44

## 変更内容

dvc.yaml の非 Git 管理方針を撤回し、dvc.lock と対で Git 管理する方針に docs を改める。

- `docs/architecture.md`: 「パイプライン定義の扱い」を Git 管理 + 整合維持（再生成・検査）の方針に書き換え。「実験追跡」から非管理由来の制約記述を除去
- `docs/components/pipeline-gen.md`: 生成の決定性（同一入力・同一バージョンでバイト一致）と整合性の維持（変更時・利用時の二つの同期点、validate の意味比較、保証範囲）を仕様化。バリデーション表に整合検査を追加
- `docs/components/cli.md`: repro / status / add-stage に dvc.yaml 再生成 + `git add` を明記。validate の検査項目にパイプライン定義整合を追加
- `docs/usecases.md` (D3 補足) / `docs/directory-layout.md` / `docs/distribution.md`: 位置づけの記述を整合させ、雛形の内容物に pre-commit 設定を追加

### 判断の根拠

- dvc.lock 単独では pipeline outs の対象列挙ができず、clone 直後の `dvc pull` が exit 0 のまま復元を空振りする（#44 で検証済み）。dvc.yaml をコミットに含めることで A4 / D4 / F3 が素の Git+DVC 操作のまま成立し、requirements の委譲表は変更不要
- 一過性生成の拡張案は、過去スナップショット復元時に現行ジェネレータで再生成する構造となり、staqkit バージョン間の出力差が当時の dvc.lock との不整合を生む。dvc.lock と対になる dvc.yaml は当時生成された一枚であり、凍結保存できるのはコミットのみ
- stage.yaml との乖離への保証モデルは「防止 + 検出」の多層構成。staqkit 経由の操作は再生成 + 内蔵 add で乖離が発生せず、非経由の変更（手編集・merge）による乖離コミットも validate の意味比較で任意スナップショットに対して検出可能。pre-commit フックと CI は雛形が配布し、有効化（`pre-commit install`・ブランチ保護）は利用者設定に依る。DVC 自身の強制機構（変更時書き込み + core.autostage + dvc status + `dvc install` フック）と層ごとに同型であり、保証水準の後退はない
- validate の比較を意味比較とするのは、将来のジェネレータのフォーマット変更が過去の正当なスナップショットの検査で偽陽性になることを防ぐため

## ドキュメント

- [x] 影響するドキュメントを更新した

🤖 Generated with [Claude Code](https://claude.com/claude-code)